### PR TITLE
implement tinyproxy BasicAuth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+conf.d/wireguard/wg_confs/*

--- a/README.MD
+++ b/README.MD
@@ -38,6 +38,8 @@ You will be able to connect to HTTP Proxy using 127.0.0.1:8888.
 Usage
 Your WireGuard VPN and TinyHTTP Proxy should now be up and running. You can configure your client device to connect to the WireGuard VPN using an HTTP Proxy running on 127.0.0.1:8888.
 
+## Basic Authentication
+To enable basic HTTP authentication for the proxy, uncomment `PROXY_BASIC_USERNAME` and `PROXY_BASIC_PASSWD`, and set their values accordingly.
 
 ## Customization
 You can customize the WireGuard and TinyHTTP Proxy configurations to suit your specific needs by editing the wireguard/wg0.conf and tinyproxy/tinyproxy.conf files respectively.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       PEERS: false
       PUID : 1000
       PGID : 1000
+#      PROXY_BASIC_USERNAME: changeme
+#      PROXY_BASIC_PASSWD: changeme
     cap_add:
       - NET_ADMIN
     volumes:

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -10,6 +10,10 @@ echo "Listen $ip" >> /tmp/tinyproxy.conf
 echo "Allow $ip" >> /tmp/tinyproxy.conf
 echo "Allow $gateway" >> /tmp/tinyproxy.conf
 echo "Allow 127.0.0.1" >> /tmp/tinyproxy.conf
+if [ -n "$PROXY_BASIC_USERNAME" ] && [ -n "$PROXY_BASIC_PASSWD" ]; then
+    echo "BasicAuth environment is configured. Omitting it to tinyproxy.conf."
+    echo "BasicAuth $PROXY_BASIC_USERNAME $PROXY_BASIC_PASSWD" >> /tmp/tinyproxy.conf
+fi
 
 cat /tmp/tinyproxy.conf
 #Run tinyproxy


### PR DESCRIPTION
This commit is authored with reference to [ericzon/b8d52012](https://gist.github.com/ericzon/b8d5201249544adf14b4280c890ae53f).

When `PROXY_BASIC_USERNAME` and `PROXY_BASIC_PASSWD` are configured, BasicAuth will be enabled in tinyproxy.

![01](https://github.com/noamanahmed/wireguard-http-proxy/assets/88741696/12ef7d78-762b-462a-8f40-31bd09609718)
![02](https://github.com/noamanahmed/wireguard-http-proxy/assets/88741696/9b95cf2d-1855-45b6-970a-613eb4ad5b81)
![03](https://github.com/noamanahmed/wireguard-http-proxy/assets/88741696/7931f797-849f-44d6-9a5d-5345f4c17f1c)
